### PR TITLE
Fix workflow

### DIFF
--- a/.github/workflows/MADTest.yml
+++ b/.github/workflows/MADTest.yml
@@ -36,19 +36,20 @@ jobs:
           ls
           cd testDirectory
           go test -v
+
+      - name: Setup Java 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "semeru"
+        run: |
+          java -v
+
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
       - name: Run Android Tests
-        uses: actions/setup-java@v3
-        with:
-          java-version: "17"
-          distribution: "semeru"
         run: ./gradlew test
 
       - name: Build Project
-        uses: actions/setup-java@v3
-        with:
-          java-version: "17"
-          distribution: "semeru"
         run: ./gradlew assemble

--- a/.github/workflows/MADTest.yml
+++ b/.github/workflows/MADTest.yml
@@ -1,16 +1,16 @@
 name: MAD Practical Test
 on:
   push:
-    branches: [main]
-    
+    branches: [main, fix-workflow]
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout Source Codes
         uses: actions/checkout@v2
-        
+
       - name: Checkout Test Scripts
         uses: actions/checkout@v2
         with:
@@ -18,7 +18,7 @@ jobs:
           path: testDirectory
       - name: Check files
         run: |
-            ls
+          ls
       - name: Create Test Files
         run: |
           cp app/src/main/res/layout/activity_main.xml testDirectory/test.xml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.13.7'
+          go-version: "1.13.7"
       - name: Run XML Test
         run: |
           ls
@@ -38,9 +38,17 @@ jobs:
           go test -v
       - name: Make gradlew executable
         run: chmod +x ./gradlew
-  
+
       - name: Run Android Tests
+        uses: actions/setup-java@v3
+        with:
+          java-version: "17"
+          distribution: "semeru"
         run: ./gradlew test
-        
+
       - name: Build Project
+        uses: actions/setup-java@v3
+          with:
+            java-version: "17"
+            distribution: "semeru"
         run: ./gradlew assemble

--- a/.github/workflows/MADTest.yml
+++ b/.github/workflows/MADTest.yml
@@ -42,8 +42,6 @@ jobs:
         with:
           java-version: "17"
           distribution: "semeru"
-        run: |
-          java -v
 
       - name: Make gradlew executable
         run: chmod +x ./gradlew

--- a/.github/workflows/MADTest.yml
+++ b/.github/workflows/MADTest.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Build Project
         uses: actions/setup-java@v3
-          with:
-            java-version: "17"
-            distribution: "semeru"
+        with:
+          java-version: "17"
+          distribution: "semeru"
         run: ./gradlew assemble


### PR DESCRIPTION
This pull request attempts to fix the workflow.  The main issue at hand is that Gradle refuses to run because of a deprecated Java version (using Java 11 instead of 17). I've updated the workflow file to use IBM Semeru's Java 17 in this workflow, using `actions/setup-java@v3`.